### PR TITLE
Reuse template capture

### DIFF
--- a/asg/src/io.rs
+++ b/asg/src/io.rs
@@ -52,7 +52,7 @@ impl std::fmt::Display for Tree {
                                     Branch | Pass | NodeIndex(_) => break,
                                     Turn => Branch,
                                     Gap => Pass,
-                                    Newline => panic!("FATAL: Failed to convert tree to a string"),
+                                    Newline => return Err(std::fmt::Error),
                                 }
                             }
                         }

--- a/asg/src/latex.rs
+++ b/asg/src/latex.rs
@@ -126,7 +126,10 @@ fn with_parens(latex: String) -> String {
 
 #[cfg(test)]
 mod test {
-    use crate::{deftree, mutate::Mutations};
+    use crate::{
+        deftree,
+        mutate::{Mutations, TemplateCapture},
+    };
 
     #[test]
     fn t_negate() {
@@ -233,7 +236,8 @@ mod test {
         let tree = deftree!(/ (+ (* p x) (* p y)) (+ x y))
             .deduplicate()
             .unwrap();
-        for m in Mutations::from(&tree) {
+        let mut capture = TemplateCapture::new();
+        for m in Mutations::of(&tree, &mut capture) {
             match m {
                 Ok(mutated) => {
                     assert_ne!(mutated, tree);

--- a/asg/src/mutate.rs
+++ b/asg/src/mutate.rs
@@ -9,18 +9,16 @@ use crate::{
 
 pub struct Mutations<'a> {
     tree: &'a Tree,
-    capture: Capture,
+    capture: TemplateCapture,
     template_index: usize,
-    reset: bool,
 }
 
 impl<'a> Mutations<'a> {
     pub fn from(tree: &'a Tree) -> Mutations {
         Mutations {
             tree,
-            capture: Capture::new(),
+            capture: TemplateCapture::new(),
             template_index: 0,
-            reset: true,
         }
     }
 }
@@ -31,117 +29,17 @@ impl<'a> Iterator for Mutations<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let templates = get_templates();
         while self.template_index < templates.len() {
-            while self.reset || self.capture.is_valid() {
-                let template = &templates[self.template_index];
-                if self.reset {
-                    template.first_match(&self.tree, &mut self.capture);
-                    self.reset = false;
-                } else {
-                    template.next_match(&self.tree, &mut self.capture);
-                }
-                if self.capture.is_valid() {
-                    return Some(self.capture.apply(template, &self.tree));
-                } else {
-                    break;
-                }
+            let template = &templates[self.template_index];
+            while self.capture.next_match(template, self.tree) {
+                return Some(self.capture.apply(template, &self.tree));
             }
-            self.reset = true;
             self.template_index += 1;
         }
         return None;
     }
 }
 
-fn symbolic_match(
-    ldofs: &Box<[usize]>,
-    li: usize,
-    ltree: &Tree,
-    ri: usize,
-    rtree: &Tree,
-    capture: &mut Capture,
-) -> bool {
-    match (ltree.node(li), rtree.node(ri)) {
-        (Node::Constant(v1), Node::Constant(v2)) => v1 == v2,
-        (Node::Constant(_), _) => return false,
-        (Node::Symbol(label), _) => return capture.bind(*label, ri),
-        (Node::Unary(lop, input1), Node::Unary(rop, input2)) => {
-            if lop != rop {
-                return false;
-            } else {
-                return symbolic_match(ldofs, *input1, ltree, *input2, rtree, capture);
-            }
-        }
-        (Node::Unary(..), _) => return false,
-        (Node::Binary(lop, l1, r1), Node::Binary(rop, l2, r2)) => {
-            if lop != rop {
-                return false;
-            } else {
-                let (l1, r1, l2, r2) = {
-                    let mut l1 = *l1;
-                    let mut r1 = *r1;
-                    let mut l2 = *l2;
-                    let mut r2 = *r2;
-                    if !lop.is_commutative() && ldofs[l1] > ldofs[r1] {
-                        (l1, r1) = (r1, l1);
-                        (l2, r2) = (r2, l2);
-                    }
-                    (l1, r1, l2, r2)
-                };
-                let state = capture.binding_state();
-                let ordered = symbolic_match(ldofs, l1, ltree, l2, rtree, capture)
-                    && symbolic_match(ldofs, r1, ltree, r2, rtree, capture);
-                if !lop.is_commutative() || ordered {
-                    return ordered;
-                }
-                capture.restore_bindings(state);
-                return symbolic_match(ldofs, l1, ltree, r2, rtree, capture)
-                    && symbolic_match(ldofs, r1, ltree, l2, rtree, capture);
-            }
-        }
-        (Node::Binary(..), _) => return false,
-    }
-}
-
-impl Template {
-    fn match_node(&self, from: usize, tree: &Tree, capture: &mut Capture) -> bool {
-        // Clear any previous bindings to start over fresh.
-        capture.bindings.clear();
-        symbolic_match(
-            &self.dof_ping(),
-            self.ping().root_index(),
-            self.ping(),
-            from,
-            tree,
-            capture,
-        )
-    }
-
-    fn match_from(&self, index: usize, tree: &Tree, capture: &mut Capture) {
-        capture.node_index = None;
-        if index >= tree.len() {
-            return;
-        }
-        for i in index..tree.len() {
-            if self.match_node(i, tree, capture) {
-                capture.node_index = Some(i);
-                return;
-            }
-        }
-    }
-
-    pub fn first_match(&self, tree: &Tree, capture: &mut Capture) {
-        self.match_from(0, tree, capture);
-    }
-
-    pub fn next_match(&self, tree: &Tree, capture: &mut Capture) {
-        match capture.node_index {
-            Some(i) => self.match_from(i + 1, tree, capture),
-            None => return,
-        }
-    }
-}
-
-pub struct Capture {
+pub struct TemplateCapture {
     node_index: Option<usize>,
     bindings: Vec<(char, usize)>,
     node_map: Vec<usize>,
@@ -150,9 +48,9 @@ pub struct Capture {
     deduper: Deduplicater,
 }
 
-impl Capture {
-    pub fn new() -> Capture {
-        Capture {
+impl TemplateCapture {
+    pub fn new() -> TemplateCapture {
+        TemplateCapture {
             node_index: None,
             bindings: vec![],
             node_map: vec![],
@@ -166,6 +64,33 @@ impl Capture {
         &self.bindings
     }
 
+    pub fn next_match(&mut self, template: &Template, tree: &Tree) -> bool {
+        // Set self.node_index to None and choose the starting index
+        // based on what was in self.node_index before setting it to None.
+        let start: usize = match std::mem::replace(&mut self.node_index, None) {
+            Some(i) => i + 1,
+            None => 0,
+        };
+        if start >= tree.len() {
+            return false;
+        }
+        for i in start..tree.len() {
+            // Clear any previous bindings to start over fresh.
+            self.bindings.clear();
+            if self.match_node(
+                template.dof_ping(),
+                template.ping().root_index(),
+                template.ping(),
+                i,
+                tree,
+            ) {
+                self.node_index = Some(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
     fn bind(&mut self, label: char, index: usize) -> bool {
         for (l, i) in self.bindings.iter() {
             if *l == label {
@@ -176,13 +101,17 @@ impl Capture {
         return true;
     }
 
-    pub fn is_valid(&self) -> bool {
-        return self.node_index.is_some();
-    }
-
     fn add_node(&mut self, dst: &mut Vec<Node>, src: usize, node: Node) {
         self.node_map[src] = dst.len();
         dst.push(node);
+    }
+
+    fn binding_checkpoint(&self) -> usize {
+        self.bindings.len()
+    }
+
+    fn restore_bindings(&mut self, state: usize) {
+        self.bindings.truncate(state);
     }
 
     fn apply(&mut self, template: &Template, tree: &Tree) -> Result<Tree, ()> {
@@ -258,12 +187,54 @@ impl Capture {
         .map_err(|_| ());
     }
 
-    fn binding_state(&self) -> usize {
-        self.bindings.len()
-    }
-
-    fn restore_bindings(&mut self, state: usize) {
-        self.bindings.truncate(state);
+    fn match_node(
+        &mut self,
+        ldofs: &Box<[usize]>,
+        li: usize,
+        ltree: &Tree,
+        ri: usize,
+        rtree: &Tree,
+    ) -> bool {
+        match (ltree.node(li), rtree.node(ri)) {
+            (Node::Constant(v1), Node::Constant(v2)) => v1 == v2,
+            (Node::Constant(_), _) => return false,
+            (Node::Symbol(label), _) => return self.bind(*label, ri),
+            (Node::Unary(lop, input1), Node::Unary(rop, input2)) => {
+                if lop != rop {
+                    return false;
+                } else {
+                    return self.match_node(ldofs, *input1, ltree, *input2, rtree);
+                }
+            }
+            (Node::Unary(..), _) => return false,
+            (Node::Binary(lop, l1, r1), Node::Binary(rop, l2, r2)) => {
+                if lop != rop {
+                    return false;
+                } else {
+                    let (l1, r1, l2, r2) = {
+                        let mut l1 = *l1;
+                        let mut r1 = *r1;
+                        let mut l2 = *l2;
+                        let mut r2 = *r2;
+                        if !lop.is_commutative() && ldofs[l1] > ldofs[r1] {
+                            (l1, r1) = (r1, l1);
+                            (l2, r2) = (r2, l2);
+                        }
+                        (l1, r1, l2, r2)
+                    };
+                    let checkpoint = self.binding_checkpoint();
+                    let ordered = self.match_node(ldofs, l1, ltree, l2, rtree)
+                        && self.match_node(ldofs, r1, ltree, r2, rtree);
+                    if !lop.is_commutative() || ordered {
+                        return ordered;
+                    }
+                    self.restore_bindings(checkpoint);
+                    return self.match_node(ldofs, l1, ltree, r2, rtree)
+                        && self.match_node(ldofs, r1, ltree, l2, rtree);
+                }
+            }
+            (Node::Binary(..), _) => return false,
+        }
     }
 }
 
@@ -274,7 +245,7 @@ mod test {
         dedup::equivalent, deftree, template::test::get_template_by_name, walk::DepthWalker,
     };
 
-    fn t_check_bindings(capture: &Capture, template: &Template, tree: &Tree) {
+    fn t_check_bindings(capture: &TemplateCapture, template: &Template, tree: &Tree) {
         let left: Vec<_> = {
             let mut chars: Vec<_> = capture.bindings.iter().map(|(c, _i)| *c).collect();
             chars.sort();
@@ -293,10 +264,8 @@ mod test {
         let template = Template::from("add_zero", deftree!(+ x 0.), deftree!(x));
         let two: Tree = (-2.0).into();
         let tree = deftree!(+ 0 {two});
-        let mut capture = Capture::new();
-        assert!(!capture.is_valid());
-        template.first_match(&tree, &mut capture);
-        assert!(capture.is_valid());
+        let mut capture = TemplateCapture::new();
+        assert!(capture.next_match(&template, &tree));
         assert!(matches!(capture.node_index, Some(i) if i == 2));
         t_check_bindings(&capture, &template, &tree);
     }
@@ -309,10 +278,8 @@ mod test {
             deftree!(+ 1 (/ b a)),
         );
         let tree = deftree!(/ (+ p q) q).deduplicate().unwrap();
-        let mut capture = Capture::new();
-        assert!(!capture.is_valid());
-        template.first_match(&tree, &mut capture);
-        assert!(capture.is_valid());
+        let mut capture = TemplateCapture::new();
+        assert!(capture.next_match(&template, &tree));
         assert!(matches!(capture.node_index, Some(i) if i == 3));
         t_check_bindings(&capture, &template, &tree);
     }
@@ -328,25 +295,20 @@ mod test {
             .deduplicate()
             .unwrap();
         print!("{}{}", template.ping(), tree); // DEBUG
-        let mut capture = Capture::new();
-        assert!(!capture.is_valid());
-        template.first_match(&tree, &mut capture);
-        assert!(capture.is_valid());
+        let mut capture = TemplateCapture::new();
+        assert!(capture.next_match(&template, &tree));
         assert!(matches!(capture.node_index, Some(i) if i == 7));
         t_check_bindings(&capture, &template, &tree);
     }
 
     fn t_check_template(name: &str, tree: Tree, node_index: usize) {
-        let mut capture = Capture::new();
+        let mut capture = TemplateCapture::new();
         capture.node_index = None;
         capture.bindings.clear();
         let template = get_template_by_name(name).unwrap();
-        assert!(!capture.is_valid());
-        template.first_match(&tree, &mut capture);
-        if !capture.is_valid() || capture.node_index.unwrap() != node_index {
+        if !capture.next_match(&template, &tree) || capture.node_index.unwrap() != node_index {
             panic!("Template:{}Tree:{}", template.ping(), tree);
         }
-        assert!(capture.is_valid());
         assert!(matches!(capture.node_index, Some(i) if i == node_index));
         t_check_bindings(&capture, &template, &tree);
     }

--- a/asg/src/reduce.rs
+++ b/asg/src/reduce.rs
@@ -1,5 +1,5 @@
 use crate::{
-    mutate::Mutations,
+    mutate::{Mutations, TemplateCapture},
     tree::Tree,
     tree::{Node, Node::*},
 };
@@ -84,7 +84,8 @@ impl Heuristic {
 }
 
 pub fn reduce(tree: Tree) -> Result<Tree, ()> {
-    let mutations = Mutations::from(&tree);
+    let mut capture = TemplateCapture::new();
+    let mutations = Mutations::of(&tree, &mut capture);
     let mut costs = Vec::<usize>::new();
     let mut h = Heuristic::new();
     for tree in mutations {
@@ -145,10 +146,11 @@ mod test {
         before = before.deduplicate().unwrap();
         after = after.deduplicate().unwrap();
         let mut h = Heuristic::new();
+        let mut capture = TemplateCapture::new();
         assert!(h.cost(&before) > h.cost(&after));
         assert_eq!(
             1,
-            Mutations::from(&before)
+            Mutations::of(&before, &mut capture)
                 .filter_map(|t| match t {
                     Ok(tree) => {
                         if tree.equivalent(&after) {

--- a/asg/src/reduce.rs
+++ b/asg/src/reduce.rs
@@ -139,29 +139,24 @@ mod test {
         assert_eq!(h.euler_walk_cost(tree.nodes(), tree.root_index()), 4);
     }
 
-    fn check_heuristic_and_mutations(mut before: Tree, mut after: Tree) {
+    fn check_heuristic_and_mutations(before: Tree, after: Tree) {
         // Make sure the 'after' tree has lower cost than the 'before
         // tree. And that the 'after' tree is found exactly once
         // among the mutations of the 'before' tree.
-        before = before.deduplicate().unwrap();
-        after = after.deduplicate().unwrap();
+        let before = before.deduplicate().unwrap();
+        let after = after.deduplicate().unwrap();
         let mut h = Heuristic::new();
         let mut capture = TemplateCapture::new();
         assert!(h.cost(&before) > h.cost(&after));
         assert_eq!(
             1,
             Mutations::of(&before, &mut capture)
-                .filter_map(|t| match t {
-                    Ok(tree) => {
-                        if tree.equivalent(&after) {
-                            Some(1)
-                        } else {
-                            None
-                        }
-                    }
-                    Err(_) => panic!("Unable to generate mutations for tree."),
+                .filter_map(|t| if t.unwrap().equivalent(&after) {
+                    Some(())
+                } else {
+                    None
                 })
-                .sum::<usize>()
+                .count()
         );
     }
 

--- a/asg/src/template.rs
+++ b/asg/src/template.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 
 use crate::{
-    mutate::Capture,
+    mutate::TemplateCapture,
     tree::{Node::*, Tree},
 };
 
@@ -30,7 +30,7 @@ pub struct Template {
 
 /// Check the capture to see if every symbol in src is bound to every
 /// symbol in dst.
-fn complete_capture(capture: &Capture, src: &Tree, dst: &Tree) -> bool {
+fn complete_capture(capture: &TemplateCapture, src: &Tree, dst: &Tree) -> bool {
     let mut lhs: Vec<_> = capture
         .bindings()
         .iter()
@@ -114,9 +114,10 @@ impl Template {
         // mirroring will produce a redundant template. It's no harm,
         // but no use either. So in the end it is harmful because it
         // wastes resources.
-        let mut capture = Capture::new();
-        out.first_match(self.ping(), &mut capture);
-        if capture.is_valid() && complete_capture(&capture, out.ping(), self.ping()) {
+        let mut capture = TemplateCapture::new();
+        if capture.next_match(&out, self.ping())
+            && complete_capture(&capture, out.ping(), self.ping())
+        {
             return None;
         }
         return Some(out);

--- a/asg/src/template.rs
+++ b/asg/src/template.rs
@@ -276,10 +276,7 @@ pub mod test {
         let mut check_one = |name: &'static str, vardata: &[(char, f64, f64)], eps: f64| {
             use crate::test::util::compare_trees;
             // Find template by name.
-            let template = TEMPLATES
-                .iter()
-                .find(|t| t.name == name)
-                .expect(format!("No template found with name: {}", name).as_str());
+            let template = TEMPLATES.iter().find(|t| t.name == name).unwrap();
             // Check if valid trees can be made from the templates.
             print!("{}   ... ", name);
             compare_trees(&template.ping, &template.pong, vardata, 20, eps);
@@ -298,7 +295,7 @@ pub mod test {
                 &[('k', -10., 10.), ('a', -10., 10.), ('b', -10., 10.)],
                 1e-12,
             );
-            check_one("min_of_sqrt", &[('a', -10., 10.), ('b', -10., 10.)], 1e-12);
+            check_one("min_of_sqrt", &[('a', 0., 10.), ('b', 0., 10.)], 1e-12);
             check_one(
                 "rearrange_frac",
                 &[
@@ -330,7 +327,7 @@ pub mod test {
                 &[('a', 1., 5.), ('b', 1., 5.), ('k', 0.5, 3.)],
                 1e-10,
             );
-            check_one("square_sqrt", &[('a', -10., 10.)], 1e-12);
+            check_one("square_sqrt", &[('a', 0., 10.)], 1e-12);
             check_one("sqrt_square", &[('a', -10., 10.)], 1e-12);
             check_one("square_abs", &[('x', -10., 10.)], 0.);
             check_one(
@@ -367,12 +364,11 @@ pub mod test {
                 .filter(|name| !checked.contains(name))
                 .collect::<Vec<&str>>()
                 .join("\n");
-            if !unchecked.is_empty() {
-                panic!(
-                    "\nThe following templates have not been tested:\n{}\n",
-                    unchecked
-                );
-            }
+            assert!(
+                unchecked.is_empty(),
+                "\nThe following templates have not been tested:\n{}\n",
+                unchecked
+            );
         }
     }
 }

--- a/asg/src/test.rs
+++ b/asg/src/test.rs
@@ -10,12 +10,14 @@ pub mod util {
             let b = $b;
             let eps = $eps;
             let error = f64::abs(a - b);
-            if error > eps {
-                panic!(
-                    "Assertion failed: |({}) - ({})| = {:e} < {:e}",
-                    a, b, error, eps
-                );
-            }
+            assert!(
+                error <= eps,
+                "Assertion failed: |({}) - ({})| = {:e} < {:e}",
+                a,
+                b,
+                error,
+                eps
+            );
         }};
         ($a:expr, $b:expr) => {
             assert_float_eq!($a, $b, f64::EPSILON)
@@ -58,11 +60,7 @@ pub mod util {
                 continue;
             }
             // We set all the variables. Run the test.
-            assert_float_eq!(
-                eval.run().expect("Unable to compute the actual value."),
-                expectedfn(&sample[..]).expect("Unable to compute expected value."),
-                eps
-            );
+            assert_float_eq!(eval.run().unwrap(), expectedfn(&sample[..]).unwrap(), eps);
             // Clean up the index stack.
             sample.pop();
             let mut vari = vari;
@@ -102,11 +100,7 @@ pub mod util {
             if vari < nvars - 1 {
                 continue;
             }
-            assert_float_eq!(
-                eval1.run().expect("Unable to compute the actual value."),
-                eval2.run().expect("Unable to compute expected value."),
-                eps
-            );
+            assert_float_eq!(eval1.run().unwrap(), eval2.run().unwrap(), eps);
             // Clean up the index stack.
             sample.pop();
             let mut vari = vari;


### PR DESCRIPTION
* Refactor to allow reusing the same instance of template capture for mutating multiple trees.
* Simplify and optimize the tree mutation API.