### PR TITLE
Errors as values

### DIFF
--- a/asg/src/dedup.rs
+++ b/asg/src/dedup.rs
@@ -280,26 +280,29 @@ mod test {
 
     #[test]
     fn t_recursive_compare_2() {
-        let tree1 = deftree!(/ (+ (* x y) (+ b a)) (* (+ y x) (* a b)));
-        let tree2 = deftree!(/ (+ (* y x) (+ a b)) (* (+ y x) (* b a)));
+        let tree1 = deftree!(/ (+ (* x y) (+ b a)) (* (+ y x) (* a b))).unwrap();
+        let tree2 = deftree!(/ (+ (* y x) (+ a b)) (* (+ y x) (* b a))).unwrap();
         assert!(tree1.equivalent(&tree2));
     }
 
     #[test]
     fn t_recursive_compare_concat() {
-        let tree1 = deftree!(concat (+ x y) (* y x));
-        let tree2 = deftree!(concat (+ y x) (* x y));
+        let tree1 = deftree!(concat (+ x y) (* y x)).unwrap();
+        let tree2 = deftree!(concat (+ y x) (* x y)).unwrap();
         assert!(tree1.equivalent(&tree2));
         let tree1 = deftree!(concat
                              (/ 1 (log (+ x y)))
-                             (/ (+ (* x y) (+ b a)) (* (+ y x) (* a b))));
+                             (/ (+ (* x y) (+ b a)) (* (+ y x) (* a b))))
+        .unwrap();
         let tree2 = deftree!(concat
                              (/ 1 (log (+ x y)))
-                             (/ (+ (* y x) (+ a b)) (* (+ y x) (* b a))));
+                             (/ (+ (* y x) (+ a b)) (* (+ y x) (* b a))))
+        .unwrap();
         assert!(tree1.equivalent(&tree2));
         let tree2 = deftree!(concat
                              (/ 1 (log (* x y)))
-                             (/ (+ (* y x) (+ a b)) (* (+ y x) (* b a))));
+                             (/ (+ (* y x) (+ a b)) (* (+ y x) (* b a))))
+        .unwrap();
         assert!(!tree1.equivalent(&tree2));
     }
 
@@ -309,10 +312,12 @@ mod test {
         let mut pruner = Pruner::new();
         // Sanity check with the same tree.
         let a = deftree!(/ (* k (+ x y)) (+ x y))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
         let b = deftree!(/ (* k (+ x y)) (+ x y))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -338,7 +343,8 @@ mod test {
                   (- (sqrt (+ (+ (pow (- x 2.) 2.) (pow (- y 3.) 2.)) (pow (- z 4.) 2.))) 2.75)
                   (- (sqrt (+ (+ (pow (+ x 2.) 2.) (pow (- y 3.) 2.)) (pow (- z 4.) 2.))) 4.))
              (- (sqrt (+ (+ (pow (+ x 2.) 2.) (pow (+ y 3.) 2.)) (pow (- z 4.) 2.))) 5.25))
-        );
+        )
+        .unwrap();
         let nodup = tree
             .clone()
             .deduplicate(&mut dedup)
@@ -359,7 +365,7 @@ mod test {
     fn t_deduplication_2() {
         let mut dedup = Deduplicater::new();
         let mut pruner = Pruner::new();
-        let tree = deftree!(/ (pow (log (+ (sin x) 2.)) 3.) (+ (cos x) 2.));
+        let tree = deftree!(/ (pow (log (+ (sin x) 2.)) 3.) (+ (cos x) 2.)).unwrap();
         let nodup = tree
             .clone()
             .deduplicate(&mut dedup)
@@ -378,7 +384,8 @@ mod test {
             (/
              (+ (pow (sin x) 2.) (+ (pow (cos x) 2.) (* 2. (* (sin x) (cos x)))))
              (+ (pow (sin y) 2.) (+ (pow (cos y) 2.) (* 2. (* (sin y) (cos y))))))
-        );
+        )
+        .unwrap();
         let nodup = tree
             .clone()
             .deduplicate(&mut dedup)

--- a/asg/src/fold.rs
+++ b/asg/src/fold.rs
@@ -60,7 +60,11 @@ mod test {
     #[test]
     fn t_sconstant_folding_0() {
         let mut pruner = Pruner::new();
-        let tree = deftree!(* 2. 3.).fold().unwrap().prune(&mut pruner);
+        let tree = deftree!(* 2. 3.)
+            .unwrap()
+            .fold()
+            .unwrap()
+            .prune(&mut pruner);
         assert_eq!(tree.len(), 1usize);
         assert_eq!(tree.roots(), &[Constant(2. * 3.)]);
     }
@@ -71,8 +75,9 @@ mod test {
             (/
              (+ x (* 2. 3.))
              (log (+ x (/ 2. (min 5. (max 3. (- 9. 5.)))))))
-        );
-        let expected = deftree!(/ (+ x 6.) (log (+ x 0.5)));
+        )
+        .unwrap();
+        let expected = deftree!(/ (+ x 6.) (log (+ x 0.5))).unwrap();
         assert!(tree.len() > expected.len());
         let mut pruner = Pruner::new();
         let tree = tree.fold().unwrap().prune(&mut pruner);
@@ -90,12 +95,14 @@ mod test {
                 (/
                  (+ x (* 3. 3.))
                  (log (+ x (/ 8. (min 5. (max 3. (- 9. 5.)))))))
-        );
+        )
+        .unwrap();
         let expected = deftree!(
             concat
                 (/ (+ x 6.) (log (+ x 0.5)))
                 (/ (+ x 9.) (log (+ x 2.)))
-        );
+        )
+        .unwrap();
         assert!(tree.len() > expected.len());
         let mut pruner = Pruner::new();
         let tree = tree.fold().unwrap().prune(&mut pruner);
@@ -108,17 +115,19 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(+ (pow x (+ y 0)) 0)
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
             deftree!(pow (+ (+ (cos (+ x 0)) (/ 1 (+ (sin y) 0))) 0) (* 2 (+ (+ x 0) y)))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 
@@ -127,17 +136,19 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(- (pow (- x 0) (+ y 0)) 0)
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
             deftree!(pow (+ (cos (+ (- x 0) 0)) (/ 1 (- (sin (- y 0)) 0))) (* 2 (+ x (- y 0))))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 
@@ -146,16 +157,17 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(+ (pow (* 1 x) (* y 1)) 0)
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
-            deftree!(pow (+ (cos (* x (* 1 (+ 1 (* 0 x))))) (/ 1 (* (sin (- y 0)) 1))) (* (* (+ 2 0) (+ x y)) 1))
+            deftree!(pow (+ (cos (* x (* 1 (+ 1 (* 0 x))))) (/ 1 (* (sin (- y 0)) 1))) (* (* (+ 2 0) (+ x y)) 1)).unwrap()
                 .fold()
                 .unwrap().prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 
@@ -164,17 +176,19 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(pow (pow (pow x 1) (pow y 1)) (pow 1 1))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
             deftree!(pow (+ (cos (pow x (pow x (* 0 x)))) (/ 1 (sin y))) (* 2 (+ x (pow y 1))))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 
@@ -183,17 +197,19 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(pow (/ x 1) (/ y (pow x (* t 0))))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
             deftree!(pow (+ (cos (/ x 1)) (/ 1 (sin (/ y (pow t (* 0 p)))))) (* 2 (+ x y)))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 
@@ -202,18 +218,20 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(pow (+ x (* t 0)) (+ y (* t 0)))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
             deftree!(pow (+ (cos (+ x (* 0 t))) (/ 1 (sin (- y (* t 0)))))
                      (* 2 (* (+ x y) (pow t (* 0 t)))))
+            .unwrap()
             .fold()
             .unwrap()
             .prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 
@@ -222,18 +240,20 @@ mod test {
         let mut pruner = Pruner::new();
         assert_eq!(
             deftree!(* (pow x (* t 0)) (pow (* x (pow t 0)) y))
+                .unwrap()
                 .fold()
                 .unwrap()
                 .prune(&mut pruner),
-            deftree!(pow x y)
+            deftree!(pow x y).unwrap()
         );
         assert_eq!(
             deftree!(pow (+ (cos (* x (pow t 0))) (/ 1 (sin (* y (pow t (* x 0))))))
                      (* 2 (+ x (* y (pow x 0)))))
+            .unwrap()
             .fold()
             .unwrap()
             .prune(&mut pruner),
-            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y)))
+            deftree!(pow (+ (cos x) (/ 1 (sin y))) (* 2 (+ x y))).unwrap()
         );
     }
 }

--- a/asg/src/io.rs
+++ b/asg/src/io.rs
@@ -101,7 +101,8 @@ mod test {
                   (- (sqrt (+ (+ (pow (- x 2.) 2.) (pow (- y 3.) 2.)) (pow (- z 4.) 2.))) 2.75)
                   (- (sqrt (+ (+ (pow (+ x 2.) 2.) (pow (- y 3.) 2.)) (pow (- z 4.) 2.))) 4.))
              (- (sqrt (+ (+ (pow (+ x 2.) 2.) (pow (+ y 3.) 2.)) (pow (- z 4.) 2.))) 5.25))
-        );
+        )
+        .unwrap();
         assert_eq!(
             format!("{}", tree).trim(),
             "
@@ -243,7 +244,8 @@ mod test {
     fn t_concat_string_formatting() {
         let v2 = deftree!(concat
                           (+ (pow x 2.) (pow y 2.))
-                          (* (pow x 2.) (pow y 2.)));
+                          (* (pow x 2.) (pow y 2.)))
+        .unwrap();
         assert_eq!(
             format!("{}", v2).trim(),
             "

--- a/asg/src/latex.rs
+++ b/asg/src/latex.rs
@@ -152,98 +152,113 @@ mod test {
     #[test]
     fn t_negate() {
         // Symbol
-        assert_eq!("-{x}", deftree!(-x).to_latex());
+        assert_eq!("-{x}", deftree!(-x).unwrap().to_latex());
         // Unary
-        assert_eq!("-{\\sqrt{2}}", deftree!(- (sqrt 2.)).to_latex());
+        assert_eq!("-{\\sqrt{2}}", deftree!(- (sqrt 2.)).unwrap().to_latex());
         assert_eq!(
             "-{\\left|{{x} + {y}}\\right|}",
-            deftree!(- (abs (+ x y))).to_latex()
+            deftree!(- (abs (+ x y))).unwrap().to_latex()
         );
         assert_eq!(
             "-{\\sin\\left({{2}.{x}}\\right)}",
-            deftree!(- (sin (* 2 x))).to_latex()
+            deftree!(- (sin (* 2 x))).unwrap().to_latex()
         );
         assert_eq!(
             "-{\\cos\\left({{x}^{2}}\\right)}",
-            deftree!(- (cos (pow x 2))).to_latex()
+            deftree!(- (cos (pow x 2))).unwrap().to_latex()
         );
         assert_eq!(
             "-{\\tan\\left({{x}^{2}}\\right)}",
-            deftree!(- (tan (pow x 2))).to_latex()
+            deftree!(- (tan (pow x 2))).unwrap().to_latex()
         );
         assert_eq!(
             "-{\\ln\\left({{x}^{2}}\\right)}",
-            deftree!(- (log (pow x 2))).to_latex()
+            deftree!(- (log (pow x 2))).unwrap().to_latex()
         );
         assert_eq!(
             "-{e^{\\left({x}^{2}\\right)}}",
-            deftree!(- (exp (pow x 2))).to_latex()
+            deftree!(- (exp (pow x 2))).unwrap().to_latex()
         );
         // Binary
         assert_eq!(
             "-{\\left({x} + {y}\\right)}",
-            deftree!(- (+ x y)).to_latex()
+            deftree!(- (+ x y)).unwrap().to_latex()
         );
         assert_eq!(
             "-{\\left({x} - {y}\\right)}",
-            deftree!(- (- x y)).to_latex()
+            deftree!(- (- x y)).unwrap().to_latex()
         );
-        assert_eq!("-{{x}.{y}}", deftree!(- (* x y)).to_latex());
-        assert_eq!("-{\\dfrac{x}{y}}", deftree!(- (/ x y)).to_latex());
-        assert_eq!("-{{x}^{y}}", deftree!(- (pow x y)).to_latex());
+        assert_eq!("-{{x}.{y}}", deftree!(- (* x y)).unwrap().to_latex());
+        assert_eq!("-{\\dfrac{x}{y}}", deftree!(- (/ x y)).unwrap().to_latex());
+        assert_eq!("-{{x}^{y}}", deftree!(- (pow x y)).unwrap().to_latex());
         assert_eq!(
             "-{\\min\\left({x}, {y}\\right)}",
-            deftree!(- (min x y)).to_latex()
+            deftree!(- (min x y)).unwrap().to_latex()
         );
         assert_eq!(
             "-{\\max\\left({x}, {y}\\right)}",
-            deftree!(- (max x y)).to_latex()
+            deftree!(- (max x y)).unwrap().to_latex()
         );
     }
 
     #[test]
     fn t_sqrt() {
         // Symbol
-        assert_eq!("\\sqrt{x}", deftree!(sqrt x).to_latex());
+        assert_eq!("\\sqrt{x}", deftree!(sqrt x).unwrap().to_latex());
         // Unary
-        assert_eq!("\\sqrt{-{x}}", deftree!(sqrt(-x)).to_latex());
+        assert_eq!("\\sqrt{-{x}}", deftree!(sqrt(-x)).unwrap().to_latex());
         assert_eq!(
             "\\sqrt{\\left|{{x} + {y}}\\right|}",
-            deftree!(sqrt (abs (+ x y))).to_latex()
+            deftree!(sqrt (abs (+ x y))).unwrap().to_latex()
         );
         assert_eq!(
             "\\sqrt{\\sin\\left({{2}.{x}}\\right)}",
-            deftree!(sqrt (sin (* 2 x))).to_latex()
+            deftree!(sqrt (sin (* 2 x))).unwrap().to_latex()
         );
         assert_eq!(
             "\\sqrt{\\cos\\left({{x}^{2}}\\right)}",
-            deftree!(sqrt (cos (pow x 2))).to_latex()
+            deftree!(sqrt (cos (pow x 2))).unwrap().to_latex()
         );
         assert_eq!(
             "\\sqrt{\\tan\\left({{x}^{2}}\\right)}",
-            deftree!(sqrt (tan (pow x 2))).to_latex()
+            deftree!(sqrt (tan (pow x 2))).unwrap().to_latex()
         );
         assert_eq!(
             "\\sqrt{\\ln\\left({{x}^{2}}\\right)}",
-            deftree!(sqrt(log (pow x 2))).to_latex()
+            deftree!(sqrt(log (pow x 2))).unwrap().to_latex()
         );
         assert_eq!(
             "\\sqrt{e^{\\left({x}^{2}\\right)}}",
-            deftree!(sqrt(exp (pow x 2))).to_latex()
+            deftree!(sqrt(exp (pow x 2))).unwrap().to_latex()
         );
         // Binary
-        assert_eq!("\\sqrt{{x} + {y}}", deftree!(sqrt (+ x y)).to_latex());
-        assert_eq!("\\sqrt{{x} - {y}}", deftree!(sqrt (- x y)).to_latex());
-        assert_eq!("\\sqrt{{x}.{y}}", deftree!(sqrt (* x y)).to_latex());
-        assert_eq!("\\sqrt{\\dfrac{x}{y}}", deftree!(sqrt (/ x y)).to_latex());
-        assert_eq!("\\sqrt{{x}^{y}}", deftree!(sqrt (pow x y)).to_latex());
+        assert_eq!(
+            "\\sqrt{{x} + {y}}",
+            deftree!(sqrt (+ x y)).unwrap().to_latex()
+        );
+        assert_eq!(
+            "\\sqrt{{x} - {y}}",
+            deftree!(sqrt (- x y)).unwrap().to_latex()
+        );
+        assert_eq!(
+            "\\sqrt{{x}.{y}}",
+            deftree!(sqrt (* x y)).unwrap().to_latex()
+        );
+        assert_eq!(
+            "\\sqrt{\\dfrac{x}{y}}",
+            deftree!(sqrt (/ x y)).unwrap().to_latex()
+        );
+        assert_eq!(
+            "\\sqrt{{x}^{y}}",
+            deftree!(sqrt (pow x y)).unwrap().to_latex()
+        );
         assert_eq!(
             "\\sqrt{\\min\\left({x}, {y}\\right)}",
-            deftree!(sqrt (min x y)).to_latex()
+            deftree!(sqrt (min x y)).unwrap().to_latex()
         );
         assert_eq!(
             "\\sqrt{\\max\\left({x}, {y}\\right)}",
-            deftree!(sqrt (max x y)).to_latex()
+            deftree!(sqrt (max x y)).unwrap().to_latex()
         );
     }
 
@@ -251,7 +266,7 @@ mod test {
     fn t_abs() {
         assert_eq!(
             "\\left|{\\dfrac{x}{y}}\\right|",
-            deftree!(abs (/ x y)).to_latex()
+            deftree!(abs (/ x y)).unwrap().to_latex()
         );
     }
 
@@ -259,11 +274,15 @@ mod test {
     fn t_mat2x2() {
         assert_eq!(
             "\\begin{bmatrix}{a} & {c} \\\\ {b} & {d}\\end{bmatrix}",
-            deftree!(concat a b c d).reshape(2, 2).unwrap().to_latex()
+            deftree!(concat a b c d)
+                .unwrap()
+                .reshape(2, 2)
+                .unwrap()
+                .to_latex()
         );
         assert_eq!(
             "\\begin{bmatrix}{{x} + {y}} & {{x} - {y}} \\\\ {{x}.{y}} & {\\dfrac{x}{y}}\\end{bmatrix}",
-            deftree!(concat (+ x y) (* x y) (- x y) (/ x y))
+            deftree!(concat (+ x y) (* x y) (- x y) (/ x y)).unwrap()
                 .reshape(2, 2)
                 .unwrap()
                 .to_latex()
@@ -274,11 +293,11 @@ mod test {
     fn t_column_vector() {
         assert_eq!(
             "\\begin{bmatrix}{a} \\\\ {b} \\\\ {c} \\\\ {d}\\end{bmatrix}",
-            deftree!(concat a b c d).to_latex()
+            deftree!(concat a b c d).unwrap().to_latex()
         );
         assert_eq!(
             "\\begin{bmatrix}{{x} + {y}} \\\\ {{x}.{y}} \\\\ {{x} - {y}} \\\\ {\\dfrac{x}{y}}\\end{bmatrix}",
-            deftree!(concat (+ x y) (* x y) (- x y) (/ x y)).to_latex()
+            deftree!(concat (+ x y) (* x y) (- x y) (/ x y)).unwrap().to_latex()
         );
     }
 
@@ -286,11 +305,16 @@ mod test {
     fn t_row_vector() {
         assert_eq!(
             "\\begin{bmatrix}{a} & {b} & {c} & {d}\\end{bmatrix}",
-            deftree!(concat a b c d).reshape(1, 4).unwrap().to_latex()
+            deftree!(concat a b c d)
+                .unwrap()
+                .reshape(1, 4)
+                .unwrap()
+                .to_latex()
         );
         assert_eq!(
             "\\begin{bmatrix}{{x} + {y}} & {{x}.{y}} & {{x} - {y}} & {\\dfrac{x}{y}}\\end{bmatrix}",
             deftree!(concat (+ x y) (* x y) (- x y) (/ x y))
+                .unwrap()
                 .reshape(1, 4)
                 .unwrap()
                 .to_latex()

--- a/asg/src/mutate.rs
+++ b/asg/src/mutate.rs
@@ -293,9 +293,8 @@ mod test {
 
     #[test]
     fn t_match_with_dofs_1() {
-        let template = Template::from("add_zero", deftree!(+ x 0.), deftree!(x));
-        let two: Tree = (-2.0).into();
-        let tree = deftree!(+ 0 {two});
+        let template = Template::from("add_zero", deftree!(+ x 0.).unwrap(), deftree!(x).unwrap());
+        let tree = deftree!(+ 0 2).unwrap();
         let mut capture = TemplateCapture::new();
         assert!(capture.next_match(&template, &tree));
         assert!(matches!(capture.node_index, Some(i) if i == 2));
@@ -306,12 +305,13 @@ mod test {
     fn t_match_with_dofs_2() {
         let template = Template::from(
             "fraction_rearrange",
-            deftree!(/ (+ a b) a),
-            deftree!(+ 1 (/ b a)),
+            deftree!(/ (+ a b) a).unwrap(),
+            deftree!(+ 1 (/ b a)).unwrap(),
         );
         let mut dedup = Deduplicater::new();
         let mut pruner = Pruner::new();
         let tree = deftree!(/ (+ p q) q)
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -325,12 +325,13 @@ mod test {
     fn t_match_with_dofs_3() {
         let template = Template::from(
             "test",
-            deftree!(/ (+ (+ a b) (+ c d)) (+ a b)),
-            deftree!(+ 1 (/ (+ c d) (+ a b))),
+            deftree!(/ (+ (+ a b) (+ c d)) (+ a b)).unwrap(),
+            deftree!(+ 1 (/ (+ c d) (+ a b))).unwrap(),
         );
         let mut dedup = Deduplicater::new();
         let mut pruner = Pruner::new();
         let tree = deftree!(/ (+ (+ p q) (+ r s)) (+ r s))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -361,14 +362,18 @@ mod test {
 
     #[test]
     fn t_match_distribute_mul() {
-        t_check_template("distribute_mul", deftree!(* 0.5 (+ (* x 2.5) (* x 1.5))), 6);
+        t_check_template(
+            "distribute_mul",
+            deftree!(* 0.5 (+ (* x 2.5) (* x 1.5))).unwrap(),
+            6,
+        );
     }
 
     #[test]
     fn t_match_min_of_sqrt() {
         t_check_template(
             "min_of_sqrt",
-            deftree!(+ 2.57 (* 1.23 (min (sqrt 2) (sqrt 3)))),
+            deftree!(+ 2.57 (* 1.23 (min (sqrt 2) (sqrt 3)))).unwrap(),
             6,
         );
     }
@@ -377,31 +382,39 @@ mod test {
     fn t_match_rearrange_frac() {
         t_check_template(
             "rearrange_frac",
-            deftree!(sqrt (log (* (/ x 2) (/ 2 x)))),
+            deftree!(sqrt (log (* (/ x 2) (/ 2 x)))).unwrap(),
             4,
         );
     }
 
     #[test]
     fn t_match_divide_by_self() {
-        t_check_template("divide_by_self", deftree!(+ 1 (/ p p)), 2);
+        t_check_template("divide_by_self", deftree!(+ 1 (/ p p)).unwrap(), 2);
     }
 
     #[test]
     fn t_match_distribute_pow_div() {
-        t_check_template("distribute_pow_div", deftree!(pow (pow (/ 2 3) 2) 2.5), 3);
+        t_check_template(
+            "distribute_pow_div",
+            deftree!(pow (pow (/ 2 3) 2) 2.5).unwrap(),
+            3,
+        );
     }
 
     #[test]
     fn t_match_distribute_pow_mul() {
-        t_check_template("distribute_pow_mul", deftree!(pow (pow (* 2 3) 2) 2.5), 3);
+        t_check_template(
+            "distribute_pow_mul",
+            deftree!(pow (pow (* 2 3) 2) 2.5).unwrap(),
+            3,
+        );
     }
 
     #[test]
     fn t_match_square_sqrt() {
         t_check_template(
             "square_sqrt",
-            deftree!(log (+ 1 (exp (pow (sqrt 3.2556) 2)))),
+            deftree!(log (+ 1 (exp (pow (sqrt 3.2556) 2)))).unwrap(),
             4,
         );
     }
@@ -410,21 +423,25 @@ mod test {
     fn t_match_sqrt_square() {
         t_check_template(
             "sqrt_square",
-            deftree!(log (+ 1 (exp (sqrt (pow 3.2345 2.))))),
+            deftree!(log (+ 1 (exp (sqrt (pow 3.2345 2.))))).unwrap(),
             4,
         );
     }
 
     #[test]
     fn t_match_square_abs() {
-        t_check_template("square_abs", deftree!(log (+ 1 (exp (pow (abs 2) 2.)))), 3);
+        t_check_template(
+            "square_abs",
+            deftree!(log (+ 1 (exp (pow (abs 2) 2.)))).unwrap(),
+            3,
+        );
     }
 
     #[test]
     fn t_match_mul_exponents() {
         t_check_template(
             "mul_exponents",
-            deftree!(log (+ 1 (exp (pow (pow x 3.) 2.)))),
+            deftree!(log (+ 1 (exp (pow (pow x 3.) 2.)))).unwrap(),
             5,
         );
     }
@@ -433,7 +450,7 @@ mod test {
     fn t_match_add_exponents() {
         t_check_template(
             "add_exponents",
-            deftree!(log (+ 1 (exp (* (pow (log x) 2) (pow (log x) 3))))),
+            deftree!(log (+ 1 (exp (* (pow (log x) 2) (pow (log x) 3))))).unwrap(),
             7,
         );
     }
@@ -442,26 +459,34 @@ mod test {
     fn t_match_add_frac() {
         t_check_template(
             "add_frac",
-            deftree!(log (+ 1 (exp (+ (/ 2 (sqrt (+ 2 x))) (/ 3 (sqrt (+ x 2))))))),
+            deftree!(log (+ 1 (exp (+ (/ 2 (sqrt (+ 2 x))) (/ 3 (sqrt (+ x 2))))))).unwrap(),
             8,
         );
     }
 
     #[test]
     fn t_match_min_expand() {
-        t_check_template("min_expand", deftree!(log (+ 1 (exp (min x 2)))), 3);
+        t_check_template(
+            "min_expand",
+            deftree!(log (+ 1 (exp (min x 2)))).unwrap(),
+            3,
+        );
     }
 
     #[test]
     fn t_match_max_expand() {
-        t_check_template("max_expand", deftree!(log (+ 1 (exp (max x 2)))), 3);
+        t_check_template(
+            "max_expand",
+            deftree!(log (+ 1 (exp (max x 2)))).unwrap(),
+            3,
+        );
     }
 
     #[test]
     fn t_match_min_of_sub_1() {
         t_check_template(
             "min_of_sub_1",
-            deftree!(log (+ 1 (exp (min (- x 2) (- x 3))))),
+            deftree!(log (+ 1 (exp (min (- x 2) (- x 3))))).unwrap(),
             6,
         );
     }
@@ -470,10 +495,10 @@ mod test {
     fn t_match_min_of_add_1() {
         const NAME: &str = "min_of_add_1";
         // Make sure all permutations work.
-        t_check_template(NAME, deftree!(min (+ x z) (+ x y)), 5);
-        t_check_template(NAME, deftree!(min (+ z x) (+ x y)), 5);
-        t_check_template(NAME, deftree!(min (+ z x) (+ y x)), 5);
-        t_check_template(NAME, deftree!(min (+ x z) (+ y x)), 5);
+        t_check_template(NAME, deftree!(min (+ x z) (+ x y)).unwrap(), 5);
+        t_check_template(NAME, deftree!(min (+ z x) (+ x y)).unwrap(), 5);
+        t_check_template(NAME, deftree!(min (+ z x) (+ y x)).unwrap(), 5);
+        t_check_template(NAME, deftree!(min (+ x z) (+ y x)).unwrap(), 5);
     }
 
     #[test]
@@ -498,20 +523,20 @@ mod test {
         // Ensure the same template capture can be used to mutate
         // multiple trees without having to reallocate.
         assert_one_match(
-            deftree!(/ (+ (* p x) (* p y)) (+ x y)),
-            deftree!(/ (* p (+ x y)) (+ x y)),
+            deftree!(/ (+ (* p x) (* p y)) (+ x y)).unwrap(),
+            deftree!(/ (* p (+ x y)) (+ x y)).unwrap(),
             &mut capture,
         );
         // Use same capture for a second set of trees.
         assert_one_match(
-            deftree!(log (+ 1 (exp (min (sqrt x) (sqrt y))))),
-            deftree!(log (+ 1 (exp (sqrt (min x y))))),
+            deftree!(log (+ 1 (exp (min (sqrt x) (sqrt y))))).unwrap(),
+            deftree!(log (+ 1 (exp (sqrt (min x y))))).unwrap(),
             &mut capture,
         );
         // Use the same capture on a third set of trees.
         assert_one_match(
-            deftree!(/ (* (pow a b) (pow b c)) (pow c a)),
-            deftree!(* (pow a b) (/ (pow b c) (pow c a))),
+            deftree!(/ (* (pow a b) (pow b c)) (pow c a)).unwrap(),
+            deftree!(* (pow a b) (/ (pow b c) (pow c a))).unwrap(),
             &mut capture,
         );
     }
@@ -554,111 +579,116 @@ mod test {
     #[test]
     fn t_mul_add() {
         check_mutations(
-            deftree!(/ (+ (* p x) (* p y)) (+ x y)),
-            deftree!(/ (* p (+ x y)) (+ x y)),
+            deftree!(/ (+ (* p x) (* p y)) (+ x y)).unwrap(),
+            deftree!(/ (* p (+ x y)) (+ x y)).unwrap(),
         );
     }
 
     #[test]
     fn t_min_sqrt() {
         check_mutations(
-            deftree!(log (+ 1 (exp (min (sqrt x) (sqrt y))))),
-            deftree!(log (+ 1 (exp (sqrt (min x y))))),
+            deftree!(log (+ 1 (exp (min (sqrt x) (sqrt y))))).unwrap(),
+            deftree!(log (+ 1 (exp (sqrt (min x y))))).unwrap(),
         );
     }
 
     #[test]
     fn t_rearrange_frac() {
         check_mutations(
-            deftree!(* (/ (+ a b) (pow x y)) (/ (+ x y) (pow a b))),
-            deftree!(* (/ (+ a b) (pow a b)) (/ (+ x y) (pow x y))),
+            deftree!(* (/ (+ a b) (pow x y)) (/ (+ x y) (pow a b))).unwrap(),
+            deftree!(* (/ (+ a b) (pow a b)) (/ (+ x y) (pow x y))).unwrap(),
         );
     }
 
     #[test]
     fn t_rearrage_mul_div() {
         check_mutations(
-            deftree!(/ (* (pow a b) (pow b c)) (pow c a)),
-            deftree!(* (pow b c) (/ (pow a b) (pow c a))),
+            deftree!(/ (* (pow a b) (pow b c)) (pow c a)).unwrap(),
+            deftree!(* (pow b c) (/ (pow a b) (pow c a))).unwrap(),
         );
         check_mutations(
-            deftree!(/ (* (pow a b) (pow b c)) (pow c a)),
-            deftree!(* (pow a b) (/ (pow b c) (pow c a))),
+            deftree!(/ (* (pow a b) (pow b c)) (pow c a)).unwrap(),
+            deftree!(* (pow a b) (/ (pow b c) (pow c a))).unwrap(),
         );
     }
 
     #[test]
     fn t_divide_by_self() {
-        check_mutations(deftree!(/ (+ x (pow y z)) (+ (pow y z) x)), deftree!(1));
+        check_mutations(
+            deftree!(/ (+ x (pow y z)) (+ (pow y z) x)).unwrap(),
+            deftree!(1).unwrap(),
+        );
     }
 
     #[test]
     fn t_distribute_pow_div() {
         check_mutations(
-            deftree!(pow (/ (* x y) (* 2 3)) 5),
-            deftree!(/ (pow (* x y) 5) (pow (* 2 3) 5)),
+            deftree!(pow (/ (* x y) (* 2 3)) 5).unwrap(),
+            deftree!(/ (pow (* x y) 5) (pow (* 2 3) 5)).unwrap(),
         );
     }
 
     #[test]
     fn t_distribute_pow_mul() {
         check_mutations(
-            deftree!(pow (* (* x y) (* 2 3)) 5),
-            deftree!(* (pow (* x y) 5) (pow (* 2 3) 5)),
+            deftree!(pow (* (* x y) (* 2 3)) 5).unwrap(),
+            deftree!(* (pow (* x y) 5) (pow (* 2 3) 5)).unwrap(),
         );
     }
 
     #[test]
     fn t_square_sqrt() {
         check_mutations(
-            deftree!(+ 1 (log (pow (sqrt (+ 2 (exp (/ x 2)))) 2))),
-            deftree!(+ 1 (log (+ 2 (exp (/ x 2))))),
+            deftree!(+ 1 (log (pow (sqrt (+ 2 (exp (/ x 2)))) 2))).unwrap(),
+            deftree!(+ 1 (log (+ 2 (exp (/ x 2))))).unwrap(),
         );
     }
 
     #[test]
     fn t_sqrt_square() {
         check_mutations(
-            deftree!(+ 1 (log (sqrt (pow (+ 2 (exp (/ x 2))) 2)))),
-            deftree!(+ 1 (log (abs (+ 2 (exp (/ x 2)))))),
+            deftree!(+ 1 (log (sqrt (pow (+ 2 (exp (/ x 2))) 2)))).unwrap(),
+            deftree!(+ 1 (log (abs (+ 2 (exp (/ x 2)))))).unwrap(),
         );
     }
 
     #[test]
     fn t_square_abs() {
         check_mutations(
-            deftree!(exp (+ 1 (log (pow (abs (* p q)) 2)))),
-            deftree!(exp (+ 1 (log (pow (* p q) 2)))),
+            deftree!(exp (+ 1 (log (pow (abs (* p q)) 2)))).unwrap(),
+            deftree!(exp (+ 1 (log (pow (* p q) 2)))).unwrap(),
         );
     }
 
     #[test]
     fn t_mul_exponents() {
         check_mutations(
-            deftree!(exp (+ 1 (log (pow (pow p (+ 2 m)) (/ q r))))),
-            deftree!(exp (+ 1 (log (pow p (* (+ 2 m) (/ q r)))))),
+            deftree!(exp (+ 1 (log (pow (pow p (+ 2 m)) (/ q r))))).unwrap(),
+            deftree!(exp (+ 1 (log (pow p (* (+ 2 m) (/ q r)))))).unwrap(),
         );
     }
 
     #[test]
     fn t_add_exponents() {
         check_mutations(
-            deftree!(exp (+ 1 (log (* (pow p (+ 2 m)) (pow p (/ q r)))))),
-            deftree!(exp (+ 1 (log (pow p (+ (+ 2 m) (/ q r)))))),
+            deftree!(exp (+ 1 (log (* (pow p (+ 2 m)) (pow p (/ q r)))))).unwrap(),
+            deftree!(exp (+ 1 (log (pow p (+ (+ 2 m) (/ q r)))))).unwrap(),
         );
     }
 
     #[test]
     fn t_binomial_square() {
         check_mutations(
-            deftree!(pow (+ (log (+ a 1)) (log (+ b 1))) 2.),
+            deftree!(pow (+ (log (+ a 1)) (log (+ b 1))) 2.).unwrap(),
             deftree!(+ (+ (pow (log (+ a 1)) 2.) (pow (log (+ b 1)) 2.))
-                     (* 2. (* (log (+ a 1)) (log (+ b 1))))),
+                     (* 2. (* (log (+ a 1)) (log (+ b 1)))))
+            .unwrap(),
         );
         check_mutations(
-            deftree!(pow (- (log (+ a 1)) (log (+ b 1))) 2.),
+            deftree!(pow (- (log (+ a 1)) (log (+ b 1))) 2.).unwrap(),
             deftree!(- (+ (pow (log (+ a 1)) 2.) (pow (log (+ b 1)) 2.))
-                     (* 2. (* (log (+ a 1)) (log (+ b 1))))),
+                     (* 2. (* (log (+ a 1)) (log (+ b 1)))))
+            .unwrap(),
         );
     }
 
@@ -666,9 +696,13 @@ mod test {
     fn t_mutate_concat() {
         check_mutations(
             deftree!(concat (+ (* p x) (* p y)) 1.)
+                .unwrap()
                 .reshape(1, 2)
                 .unwrap(),
-            deftree!(concat (* p (+ x y)) 1.).reshape(1, 2).unwrap(),
+            deftree!(concat (* p (+ x y)) 1.)
+                .unwrap()
+                .reshape(1, 2)
+                .unwrap(),
         );
     }
 }

--- a/asg/src/reduce.rs
+++ b/asg/src/reduce.rs
@@ -186,6 +186,7 @@ mod test {
         let mut pruner = Pruner::new();
         let mut h = Heuristic::new();
         let tree = deftree!(+ x x)
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -198,6 +199,7 @@ mod test {
         let mut pruner = Pruner::new();
         let mut h = Heuristic::new();
         let tree = deftree!(+ (* 2 x) (* 3 x))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -210,12 +212,14 @@ mod test {
         let mut pruner = Pruner::new();
         let mut h = Heuristic::new();
         let tree = deftree!(+ (+ (* 2 x) (* 3 x)) (* 4 x))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
         assert_eq!(h.euler_walk_cost(tree.nodes(), tree.root_indices()), 13);
         // Make sure the same heuristic instance can be reused on other trees.
         let tree = deftree!(+ (+ (* 2 x) (* 3 x)) (+ (* 4 x) 2))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -228,6 +232,7 @@ mod test {
         let mut pruner = Pruner::new();
         let mut h = Heuristic::new();
         let tree = deftree!(+ (* 2 (+ x y)) (* (+ x y) 3))
+            .unwrap()
             .deduplicate(&mut dedup)
             .unwrap()
             .prune(&mut pruner);
@@ -260,32 +265,33 @@ mod test {
     #[test]
     fn t_heuristic_cost_1() {
         check_heuristic_and_mutations(
-            deftree!(/ (+ (* p x) (* p y)) (+ x y)),
-            deftree!(/ (* p (+ x y)) (+ x y)),
+            deftree!(/ (+ (* p x) (* p y)) (+ x y)).unwrap(),
+            deftree!(/ (* p (+ x y)) (+ x y)).unwrap(),
         );
     }
 
     #[test]
     fn t_heuristic_cost_2() {
         check_heuristic_and_mutations(
-            deftree!(log (+ 1 (exp (min (sqrt x) (sqrt y))))),
-            deftree!(log (+ 1 (exp (sqrt (min x y))))),
+            deftree!(log (+ 1 (exp (min (sqrt x) (sqrt y))))).unwrap(),
+            deftree!(log (+ 1 (exp (sqrt (min x y))))).unwrap(),
         );
     }
 
     #[test]
     fn t_reduce_0() {
-        let tree = deftree!(/ (+ (* p x) (* p y)) (+ x y));
+        let tree = deftree!(/ (+ (* p x) (* p y)) (+ x y)).unwrap();
         let steps = reduce(tree, 8).unwrap();
-        assert!(steps.last().unwrap().equivalent(&deftree!(p)));
+        assert!(steps.last().unwrap().equivalent(&deftree!(p).unwrap()));
     }
 
     #[test]
     fn t_reduce_1() {
         let tree = deftree!(sqrt (+ (pow (/ x (sqrt (+ (pow x 2) (pow y 2)))) 2)
-                                  (pow (/ y (sqrt (+ (pow x 2) (pow y 2)))) 2)));
+                                  (pow (/ y (sqrt (+ (pow x 2) (pow y 2)))) 2)))
+        .unwrap();
         let steps = reduce(tree, 8).unwrap();
-        assert!(steps.last().unwrap().equivalent(&deftree!(1)));
+        assert!(steps.last().unwrap().equivalent(&deftree!(1).unwrap()));
     }
 
     #[test]
@@ -293,9 +299,13 @@ mod test {
         let tree = deftree!(concat
                             (/ (+ (* p x) (* p y)) (+ x y))
                             1.
-        );
+        )
+        .unwrap();
         let steps = reduce(tree, 8).unwrap();
-        assert!(steps.last().unwrap().equivalent(&deftree!(concat p 1)));
+        assert!(steps
+            .last()
+            .unwrap()
+            .equivalent(&deftree!(concat p 1).unwrap()));
     }
 
     #[test]
@@ -303,9 +313,13 @@ mod test {
         let tree = deftree!(concat
                             (sqrt (+ (pow (/ x (sqrt (+ (pow x 2) (pow y 2)))) 2)
                                    (pow (/ y (sqrt (+ (pow x 2) (pow y 2)))) 2)))
-                            42.);
+                            42.)
+        .unwrap();
         let steps = reduce(tree, 8).unwrap();
-        assert!(steps.last().unwrap().equivalent(&deftree!(concat 1. 42.)));
+        assert!(steps
+            .last()
+            .unwrap()
+            .equivalent(&deftree!(concat 1. 42.).unwrap()));
     }
 
     #[test]
@@ -313,8 +327,12 @@ mod test {
         let tree = deftree!(concat
                             (/ (+ (* p x) (* p y)) (+ x y))
                             (sqrt (+ (pow (/ x (sqrt (+ (pow x 2) (pow y 2)))) 2)
-                                   (pow (/ y (sqrt (+ (pow x 2) (pow y 2)))) 2))));
+                                   (pow (/ y (sqrt (+ (pow x 2) (pow y 2)))) 2))))
+        .unwrap();
         let steps = reduce(tree, 12).unwrap();
-        assert!(steps.last().unwrap().equivalent(&deftree!(concat p 1.)));
+        assert!(steps
+            .last()
+            .unwrap()
+            .equivalent(&deftree!(concat p 1.).unwrap()));
     }
 }

--- a/asg/src/template.rs
+++ b/asg/src/template.rs
@@ -13,8 +13,8 @@ macro_rules! deftemplate {
     ($name: ident ping ($($ping:tt) *) pong ($($pong:tt) *)) => {
         Template::from(
             stringify!($name),
-            $crate::deftree!(($($ping) *)),
-            $crate::deftree!(($($pong) *))
+            $crate::deftree!(($($ping) *)).unwrap(),
+            $crate::deftree!(($($pong) *)).unwrap()
         )
     };
 }

--- a/asg/src/tree.rs
+++ b/asg/src/tree.rs
@@ -100,7 +100,7 @@ impl BinaryOp {
 use {BinaryOp::*, UnaryOp::*};
 
 /// Errors that can occur when constructing a tree.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TreeError {
     /// Nodes are not in a valid topological order.
     WrongNodeOrder,
@@ -132,6 +132,8 @@ pub struct Tree {
     dims: (usize, usize),
 }
 
+pub type MaybeTree = Result<Tree, TreeError>;
+
 const fn matsize(dims: (usize, usize)) -> usize {
     dims.0 * dims.1
 }
@@ -153,7 +155,9 @@ impl Tree {
         }
     }
 
-    pub fn concat(mut lhs: Tree, mut rhs: Tree) -> Tree {
+    pub fn concat(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+        let mut lhs = lhs?;
+        let mut rhs = rhs?;
         let (llen, lsize) = (lhs.len(), lhs.num_roots());
         let (rlen, rsize) = (rhs.len(), rhs.num_roots());
         {
@@ -172,7 +176,7 @@ impl Tree {
         // concatenations makes sure all the root nodes are at the end.
         lhs.nodes[(llen - lsize)..(llen + rlen - rsize)].rotate_left(lsize);
         lhs.dims = (lsize + rsize, 1);
-        return lhs;
+        return Ok(lhs);
     }
 
     pub fn transposed(mut self) -> Tree {
@@ -193,7 +197,7 @@ impl Tree {
         self.dims
     }
 
-    pub fn reshape(self, rows: usize, cols: usize) -> Result<Tree, TreeError> {
+    pub fn reshape(self, rows: usize, cols: usize) -> MaybeTree {
         if matsize((rows, cols)) == self.num_roots() {
             Ok(Tree {
                 nodes: self.nodes,
@@ -253,7 +257,7 @@ impl Tree {
 
     /// Check the tree for errors and return a Result that contains the tree if
     /// no errors were found, or the first error encountered with the tree.
-    pub fn validated(self) -> Result<Tree, TreeError> {
+    pub fn validated(self) -> MaybeTree {
         if self.nodes.is_empty() {
             return Err(TreeError::EmptyTree);
         }
@@ -269,9 +273,13 @@ impl Tree {
         return Ok(self);
     }
 
-    fn binary_op(mut self, other: Tree, op: BinaryOp) -> Tree {
-        if self.num_roots() > other.num_roots() {
+    fn binary_op(mut self, other: Tree, op: BinaryOp) -> MaybeTree {
+        let nroots = self.num_roots();
+        let other_nroots = other.num_roots();
+        if nroots > other_nroots {
             return other.binary_op(self, op);
+        } else if nroots != 1 && nroots != other_nroots {
+            return Err(TreeError::DimensionMismatch(self.dims, other.dims));
         }
         let offset: usize = self.nodes.len();
         self.nodes.reserve(self.nodes.len() + other.nodes.len() + 1);
@@ -281,52 +289,68 @@ impl Tree {
             Unary(op, input) => Unary(*op, *input + offset),
             Binary(op, lhs, rhs) => Binary(*op, *lhs + offset, *rhs + offset),
         }));
-        if self.num_roots() == 1 {
+        if nroots == 1 {
             for r in other.root_indices() {
                 self.nodes.push(Binary(op, offset - 1, r + offset));
             }
         } else {
-            for (l, r) in ((offset - self.num_roots())..offset).zip(other.root_indices()) {
+            for (l, r) in ((offset - nroots)..offset).zip(other.root_indices()) {
                 self.nodes.push(Binary(op, l, r + offset));
             }
         }
-        return self;
+        return Ok(self);
     }
 
-    fn unary_op(mut self, op: UnaryOp) -> Tree {
+    fn unary_op(mut self, op: UnaryOp) -> MaybeTree {
         for root in self.root_indices() {
             self.nodes.push(Unary(op, root));
         }
-        return self;
+        return Ok(self);
     }
 }
 
-impl core::ops::Add<Tree> for Tree {
-    type Output = Tree;
+pub fn add(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+    lhs?.binary_op(rhs?, Add)
+}
 
-    fn add(self, rhs: Tree) -> Tree {
+impl core::ops::Add<Tree> for Tree {
+    type Output = MaybeTree;
+
+    fn add(self, rhs: Tree) -> Self::Output {
         self.binary_op(rhs, Add)
     }
 }
 
+pub fn sub(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+    lhs?.binary_op(rhs?, Subtract)
+}
+
 impl core::ops::Sub<Tree> for Tree {
-    type Output = Tree;
+    type Output = MaybeTree;
 
     fn sub(self, rhs: Tree) -> Self::Output {
         self.binary_op(rhs, Subtract)
     }
 }
 
-impl core::ops::Mul<Tree> for Tree {
-    type Output = Tree;
+pub fn mul(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+    lhs?.binary_op(rhs?, Multiply)
+}
 
-    fn mul(self, rhs: Tree) -> Tree {
+impl core::ops::Mul<Tree> for Tree {
+    type Output = MaybeTree;
+
+    fn mul(self, rhs: Tree) -> Self::Output {
         self.binary_op(rhs, Multiply)
     }
 }
 
+pub fn div(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+    lhs?.binary_op(rhs?, Divide)
+}
+
 impl core::ops::Div<Tree> for Tree {
-    type Output = Tree;
+    type Output = MaybeTree;
 
     fn div(self, rhs: Tree) -> Self::Output {
         self.binary_op(rhs, Divide)
@@ -335,22 +359,26 @@ impl core::ops::Div<Tree> for Tree {
 
 /// Construct a tree that represents raising `base` to the power of
 /// `exponent`.
-pub fn pow(base: Tree, exponent: Tree) -> Tree {
-    base.binary_op(exponent, Pow)
+pub fn pow(base: MaybeTree, exponent: MaybeTree) -> MaybeTree {
+    base?.binary_op(exponent?, Pow)
 }
 
 /// Construct a tree that represents the smaller of `lhs` and `rhs`.
-pub fn min(lhs: Tree, rhs: Tree) -> Tree {
-    lhs.binary_op(rhs, Min)
+pub fn min(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+    lhs?.binary_op(rhs?, Min)
 }
 
 /// Construct a tree that represents the larger of `lhs` and `rhs`.
-pub fn max(lhs: Tree, rhs: Tree) -> Tree {
-    lhs.binary_op(rhs, Max)
+pub fn max(lhs: MaybeTree, rhs: MaybeTree) -> MaybeTree {
+    lhs?.binary_op(rhs?, Max)
+}
+
+pub fn negate(tree: MaybeTree) -> MaybeTree {
+    tree?.unary_op(Negate)
 }
 
 impl core::ops::Neg for Tree {
-    type Output = Tree;
+    type Output = MaybeTree;
 
     fn neg(self) -> Self::Output {
         self.unary_op(Negate)
@@ -358,38 +386,38 @@ impl core::ops::Neg for Tree {
 }
 
 /// Construct a tree representing the square root of `x`.
-pub fn sqrt(x: Tree) -> Tree {
-    x.unary_op(Sqrt)
+pub fn sqrt(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Sqrt)
 }
 
 /// Construct a tree representing the absolute value of `x`.
-pub fn abs(x: Tree) -> Tree {
-    x.unary_op(Abs)
+pub fn abs(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Abs)
 }
 
 /// Construct a tree representing the sine of `x`.
-pub fn sin(x: Tree) -> Tree {
-    x.unary_op(Sin)
+pub fn sin(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Sin)
 }
 
 /// Construct a tree representing the cosine of `x`.
-pub fn cos(x: Tree) -> Tree {
-    x.unary_op(Cos)
+pub fn cos(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Cos)
 }
 
 /// Construct a tree representing the tangent of 'x'.
-pub fn tan(x: Tree) -> Tree {
-    x.unary_op(Tan)
+pub fn tan(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Tan)
 }
 
 /// Construct a tree representing the natural logarithm of `x`.
-pub fn log(x: Tree) -> Tree {
-    x.unary_op(Log)
+pub fn log(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Log)
 }
 
 /// Construct a tree representing `e` raised to the power of `x`.
-pub fn exp(x: Tree) -> Tree {
-    x.unary_op(Exp)
+pub fn exp(x: MaybeTree) -> MaybeTree {
+    x?.unary_op(Exp)
 }
 
 impl From<f64> for Tree {
@@ -445,17 +473,20 @@ mod test {
     fn t_add() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let sum = x + y;
-        assert_eq!(sum.nodes, vec![Symbol('x'), Symbol('y'), Binary(Add, 0, 1)]);
+        let out = x + y;
+        assert_eq!(
+            out.unwrap().nodes,
+            vec![Symbol('x'), Symbol('y'), Binary(Add, 0, 1)]
+        );
     }
 
     #[test]
     fn t_multiply() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let sum = x * y;
+        let out = x * y;
         assert_eq!(
-            sum.nodes,
+            out.unwrap().nodes,
             vec![Symbol('x'), Symbol('y'), Binary(Multiply, 0, 1)]
         );
     }
@@ -464,9 +495,9 @@ mod test {
     fn t_subtract() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let sum = x - y;
+        let out = x - y;
         assert_eq!(
-            sum.nodes,
+            out.unwrap().nodes,
             vec![Symbol('x'), Symbol('y'), Binary(Subtract, 0, 1)]
         );
     }
@@ -475,9 +506,9 @@ mod test {
     fn t_divide() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let sum = x / y;
+        let out = x / y;
         assert_eq!(
-            sum.nodes,
+            out.unwrap().nodes,
             vec![Symbol('x'), Symbol('y'), Binary(Divide, 0, 1)]
         );
     }
@@ -486,92 +517,101 @@ mod test {
     fn t_pow() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let p = pow(x, y);
-        assert_eq!(p.nodes, vec![Symbol('x'), Symbol('y'), Binary(Pow, 0, 1)]);
+        let p = pow(Ok(x), Ok(y));
+        assert_eq!(
+            p.unwrap().nodes,
+            vec![Symbol('x'), Symbol('y'), Binary(Pow, 0, 1)]
+        );
     }
 
     #[test]
     fn t_min() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let m = min(x, y);
-        assert_eq!(m.nodes, vec![Symbol('x'), Symbol('y'), Binary(Min, 0, 1)]);
+        let m = min(Ok(x), Ok(y));
+        assert_eq!(
+            m.unwrap().nodes,
+            vec![Symbol('x'), Symbol('y'), Binary(Min, 0, 1)]
+        );
     }
 
     #[test]
     fn t_max() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let m = max(x, y);
-        assert_eq!(m.nodes, vec![Symbol('x'), Symbol('y'), Binary(Max, 0, 1)]);
+        let m = max(Ok(x), Ok(y));
+        assert_eq!(
+            m.unwrap().nodes,
+            vec![Symbol('x'), Symbol('y'), Binary(Max, 0, 1)]
+        );
     }
 
     #[test]
     fn t_negate() {
         let x: Tree = 'x'.into();
         let neg = -x;
-        assert_eq!(neg.nodes, vec![Symbol('x'), Unary(Negate, 0)]);
+        assert_eq!(neg.unwrap().nodes, vec![Symbol('x'), Unary(Negate, 0)]);
     }
 
     #[test]
     fn t_sqrt_test() {
         let x: Tree = 'x'.into();
-        let y = sqrt(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Sqrt, 0)]);
+        let y = sqrt(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Sqrt, 0)]);
     }
 
     #[test]
     fn t_abs_test() {
         let x: Tree = 'x'.into();
-        let y = abs(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Abs, 0)]);
+        let y = abs(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Abs, 0)]);
     }
 
     #[test]
     fn t_sin_test() {
         let x: Tree = 'x'.into();
-        let y = sin(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Sin, 0)]);
+        let y = sin(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Sin, 0)]);
     }
 
     #[test]
     fn t_cos_test() {
         let x: Tree = 'x'.into();
-        let y = cos(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Cos, 0)]);
+        let y = cos(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Cos, 0)]);
     }
 
     #[test]
     fn t_tan_test() {
         let x: Tree = 'x'.into();
-        let y = tan(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Tan, 0)]);
+        let y = tan(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Tan, 0)]);
     }
 
     #[test]
     fn t_log_test() {
         let x: Tree = 'x'.into();
-        let y = log(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Log, 0)]);
+        let y = log(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Log, 0)]);
     }
 
     #[test]
     fn t_exp_test() {
         let x: Tree = 'x'.into();
-        let y = exp(x);
-        assert_eq!(y.nodes, vec![Symbol('x'), Unary(Exp, 0)]);
+        let y = exp(Ok(x));
+        assert_eq!(y.unwrap().nodes, vec![Symbol('x'), Unary(Exp, 0)]);
     }
 
     #[test]
     fn t_element_wise_unary_op() {
         let x: Tree = 'x'.into();
         let y: Tree = 'y'.into();
-        let p = Tree::concat(x, y);
+        let p = Tree::concat(Ok(x), Ok(y)).unwrap();
         assert_eq!(p.dims, (2, 1));
         assert_eq!(p.nodes, vec![Symbol('x'), Symbol('y')]);
         let p = p * 2.0.into();
         assert_eq!(
-            p.nodes,
+            p.unwrap().nodes,
             vec![
                 Constant(2.),
                 Symbol('x'),
@@ -585,7 +625,10 @@ mod test {
     #[test]
     fn t_element_wise_binary_op() {
         // Matrix and a scalar.
-        let tree = Tree::concat(Tree::concat('x'.into(), 'y'.into()), 'z'.into()) * 2.0.into();
+        let tree = mul(
+            Tree::concat(Tree::concat(Ok('x'.into()), Ok('y'.into())), Ok('z'.into())),
+            Ok(2.0.into()),
+        );
         let expected = vec![
             Constant(2.),
             Symbol('x'),
@@ -595,16 +638,20 @@ mod test {
             Binary(Multiply, 0, 2),
             Binary(Multiply, 0, 3),
         ];
-        assert_eq!(tree.nodes, expected);
+        assert_eq!(tree.unwrap().nodes, expected);
         // Scalar and a matrix
-        let tree =
-            Tree::constant(2.) * Tree::concat(Tree::concat('x'.into(), 'y'.into()), 'z'.into());
-        assert_eq!(tree.nodes, expected);
+        let tree = mul(
+            Ok(Tree::constant(2.)),
+            Tree::concat(Tree::concat(Ok('x'.into()), Ok('y'.into())), Ok('z'.into())),
+        );
+        assert_eq!(tree.unwrap().nodes, expected);
         // Matrix and a matrix - multiply
-        let tree = Tree::concat(Tree::concat('x'.into(), 'y'.into()), 'z'.into())
-            * Tree::concat(Tree::concat('a'.into(), 'b'.into()), 'c'.into());
+        let tree = mul(
+            Tree::concat(Tree::concat(Ok('x'.into()), Ok('y'.into())), Ok('z'.into())),
+            Tree::concat(Tree::concat(Ok('a'.into()), Ok('b'.into())), Ok('c'.into())),
+        );
         assert_eq!(
-            tree.nodes,
+            tree.unwrap().nodes,
             vec![
                 Symbol('x'),
                 Symbol('y'),
@@ -618,10 +665,12 @@ mod test {
             ]
         );
         // Matrix and a matrix - add.
-        let tree = Tree::concat(Tree::concat('x'.into(), 'y'.into()), 'z'.into())
-            + Tree::concat(Tree::concat('a'.into(), 'b'.into()), 'c'.into());
+        let tree = add(
+            Tree::concat(Tree::concat(Ok('x'.into()), Ok('y'.into())), Ok('z'.into())),
+            Tree::concat(Tree::concat(Ok('a'.into()), Ok('b'.into())), Ok('c'.into())),
+        );
         assert_eq!(
-            tree.nodes,
+            tree.unwrap().nodes,
             vec![
                 Symbol('x'),
                 Symbol('y'),
@@ -635,26 +684,28 @@ mod test {
             ]
         );
         // Matrices of different sizes.
-        let tree = Tree::concat(Tree::concat('x'.into(), 'y'.into()), 'z'.into())
-            * Tree::concat('a'.into(), 'b'.into());
-        let expected = vec![
-            Symbol('a'),
-            Symbol('b'),
-            Symbol('x'),
-            Symbol('y'),
-            Symbol('z'),
-            Binary(Multiply, 0, 2),
-            Binary(Multiply, 1, 3),
-        ];
-        assert_eq!(tree.nodes, expected);
-        let tree = Tree::concat('a'.into(), 'b'.into())
-            * Tree::concat('x'.into(), Tree::concat('y'.into(), 'z'.into()));
-        assert_eq!(tree.nodes, expected);
+        matches!(
+            mul(
+                Tree::concat(Tree::concat(Ok('x'.into()), Ok('y'.into())), Ok('z'.into())),
+                Tree::concat(Ok('a'.into()), Ok('b'.into())),
+            ),
+            Err(TreeError::DimensionMismatch((2, 1), (3, 1)))
+        );
+        matches!(
+            mul(
+                Tree::concat(Ok('a'.into()), Ok('b'.into())),
+                Tree::concat(Ok('x'.into()), Tree::concat(Ok('y'.into()), Ok('z'.into()))),
+            ),
+            Err(TreeError::DimensionMismatch((2, 1), (3, 1)))
+        );
     }
 
     #[test]
     fn t_reshape() {
-        let mat = deftree!(concat a b c p q r x y z).reshape(3, 3).unwrap();
+        let mat = deftree!(concat a b c p q r x y z)
+            .unwrap()
+            .reshape(3, 3)
+            .unwrap();
         assert_eq!(mat.dims(), (3, 3));
         let mat = mat.reshape(1, 9).unwrap();
         assert_eq!(mat.dims(), (1, 9));

--- a/asg/src/walk.rs
+++ b/asg/src/walk.rs
@@ -185,7 +185,7 @@ mod test {
     fn t_depth_traverse() {
         let mut walker = DepthWalker::new();
         {
-            let tree = deftree!(+ (pow x 2.) (pow y 2.));
+            let tree = deftree!(+ (pow x 2.) (pow y 2.)).unwrap();
             // Make sure two successive traversal yield the same nodes.
             let a: Vec<_> = walker
                 .walk_tree(&tree, true, NodeOrdering::Original)
@@ -199,7 +199,7 @@ mod test {
         }
         {
             // Make sure the same TraverseDepth can be used on multiple trees.
-            let tree = deftree!(+ (pow x 3.) (pow y 3.));
+            let tree = deftree!(+ (pow x 3.) (pow y 3.)).unwrap();
             let a: Vec<_> = walker
                 .walk_tree(&tree, true, NodeOrdering::Original)
                 .map(|(index, parent)| (index, parent))

--- a/testbench/src/main.rs
+++ b/testbench/src/main.rs
@@ -1,7 +1,7 @@
 use asg::{deftree, reduce::reduce};
 
 fn main() {
-    let tree = deftree!(/ (+ (* k x) (* k y)) (+ x y));
+    let tree = deftree!(/ (+ (* k x) (* k y)) (+ x y)).unwrap();
     let max_iter = 10;
     println!("${}$\n", tree.to_latex());
     let steps = reduce(tree, max_iter).unwrap();


### PR DESCRIPTION
Considering the changes I plan to make next, errors when constructing trees can only be detected at runtime. This change propagates these errors as values.